### PR TITLE
Custom regex for variables

### DIFF
--- a/BooleanExpressionEvaluation.xcodeproj/project.pbxproj
+++ b/BooleanExpressionEvaluation.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		BD12A22423A66431003BC568 /* OperatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD12A22323A66431003BC568 /* OperatorProtocol.swift */; };
 		BD12A22623A66577003BC568 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD12A22523A66577003BC568 /* Operator.swift */; };
 		BD12A22F23A6CC66003BC568 /* LogicOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD12A22E23A6CC66003BC568 /* LogicOperator.swift */; };
+		BD12A23123A6DA2D003BC568 /* VariablePatternTestsIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD12A23023A6DA2D003BC568 /* VariablePatternTestsIntegration.swift */; };
 		BDB6C4762392D4E70027D01F /* BooleanExpressionTokenizorTestsIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6C4752392D4E70027D01F /* BooleanExpressionTokenizorTestsIntegration.swift */; };
 		BDB6C4782392D5C00027D01F /* ExpressionEvaluatorTestsIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6C4772392D5C00027D01F /* ExpressionEvaluatorTestsIntegration.swift */; };
 		BDE6B086238E5FA90021D4AD /* BooleanExpressionEvaluation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE6B07C238E5FA90021D4AD /* BooleanExpressionEvaluation.framework */; };
@@ -48,6 +49,7 @@
 		BD12A22323A66431003BC568 /* OperatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorProtocol.swift; sourceTree = "<group>"; };
 		BD12A22523A66577003BC568 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		BD12A22E23A6CC66003BC568 /* LogicOperator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogicOperator.swift; sourceTree = "<group>"; };
+		BD12A23023A6DA2D003BC568 /* VariablePatternTestsIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VariablePatternTestsIntegration.swift; path = Pods/VariablePatternTestsIntegration.swift; sourceTree = SOURCE_ROOT; };
 		BDB6C4752392D4E70027D01F /* BooleanExpressionTokenizorTestsIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanExpressionTokenizorTestsIntegration.swift; sourceTree = "<group>"; };
 		BDB6C4772392D5C00027D01F /* ExpressionEvaluatorTestsIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorTestsIntegration.swift; sourceTree = "<group>"; };
 		BDE6B07C238E5FA90021D4AD /* BooleanExpressionEvaluation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BooleanExpressionEvaluation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -149,6 +151,7 @@
 		BDE6B089238E5FA90021D4AD /* BooleanExpressionEvaluationTests */ = {
 			isa = PBXGroup;
 			children = (
+				BD12A23023A6DA2D003BC568 /* VariablePatternTestsIntegration.swift */,
 				BDE6B0AD238E638D0021D4AD /* Expression */,
 				BDE6B08C238E5FA90021D4AD /* Info.plist */,
 			);
@@ -400,6 +403,7 @@
 			files = (
 				BDE6B0B7238E638D0021D4AD /* ExpressionTests.swift in Sources */,
 				BDE6B0B4238E638D0021D4AD /* BooleanExpressionTokenizorTests.swift in Sources */,
+				BD12A23123A6DA2D003BC568 /* VariablePatternTestsIntegration.swift in Sources */,
 				BDE6B0B5238E638D0021D4AD /* ExpressionElementTests.swift in Sources */,
 				BDB6C4782392D5C00027D01F /* ExpressionEvaluatorTestsIntegration.swift in Sources */,
 				BDE6B0B6238E638D0021D4AD /* ExpressionEvaluatorTests.swift in Sources */,

--- a/BooleanExpressionEvaluation/Expression/Operator/LogicOperator.swift
+++ b/BooleanExpressionEvaluation/Expression/Operator/LogicOperator.swift
@@ -21,7 +21,6 @@ import Foundation
 
 public struct LogicOperator: OperatorProtocol {
 
-
     // MARK: - Constants
 
     typealias Evaluation = (Bool, Bool) -> Bool

--- a/BooleanExpressionEvaluation/Extensions/NSRegularExpressionExtension.swift
+++ b/BooleanExpressionEvaluation/Extensions/NSRegularExpressionExtension.swift
@@ -42,8 +42,31 @@ extension NSRegularExpression {
         return string.sliced(with: range)
     }
 
-    func matches(in string: String) -> [String] {
+    /**
+     - Parameter string: The string to look for the matches in
+     - Returns: The string matches found by the regular expression. Throws an error if an element of the string has no match.
+     */
+    func matches(in string: String) throws -> [String] {
         let matches = self.matches(in: string, options: [], range: NSRange(location: 0, length: string.count))
-        return matches.map { string.sliced(with: $0.range) }
+
+        var stringMatches = [String]()
+        var lastMatchUpperBound = 0
+
+        for match in matches {
+            // check if we have ignored characters between the previous and current match
+            if match.range.lowerBound > lastMatchUpperBound {
+                let rangeBetweenMatches = NSRange(lastMatchUpperBound...match.range.lowerBound - 1)
+                let subStringBetweenMatches = string.sliced(with: rangeBetweenMatches)
+                if subStringBetweenMatches.trimmingCharacters(in: .whitespaces) != "" {
+                    // we have something between those two matches, so it's an unmatched element.
+                    throw ExpressionError.incorrectElement(subStringBetweenMatches)
+                }
+            }
+
+            lastMatchUpperBound = match.range.upperBound
+            stringMatches.append(string.sliced(with: match.range))
+        }
+
+        return stringMatches
     }
 }

--- a/Pods/VariablePatternTestsIntegration.swift
+++ b/Pods/VariablePatternTestsIntegration.swift
@@ -1,0 +1,45 @@
+////
+//  GNU GPLv3
+//
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see https://www.gnu.org/licenses
+    for more information.
+*/
+
+import XCTest
+@testable import BooleanExpressionEvaluation
+
+class VariablePatternTestsIntegration: XCTestCase {
+
+    // MARK: - Constants
+
+    let variablesRegexPattern = "[a-zA-Z#]{1}[a-zA-Z0-9#]+"
+
+    func test1() {
+        let expression = try? Expression("#variable >= 2", variablesRegexPattern: variablesRegexPattern)
+        let expectedExpression: Expression = [.operand(.variable("#variable")), .comparisonOperator(.greaterThanOrEqual), .operand(.number(2))]
+
+        XCTAssertEqual(expression, expectedExpression)
+    }
+
+    func test2() {
+        XCTAssertThrowsError(try Expression("#variable -= 2", variablesRegexPattern: variablesRegexPattern), "") { error in
+            guard case let ExpressionError.incorrectElement(element) = error else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(element, " -= ")
+        }
+    }
+}


### PR DESCRIPTION
It's now possible to override the default variables pattern regex to allow the match for other variable names. Require to add the pattern as as parameter when initializing the `Expression`