### PR TITLE
String regex fixed to prevent a double quote to be valid inside duble quotes

### DIFF
--- a/BooleanExpressionEvaluation.xcodeproj/project.pbxproj
+++ b/BooleanExpressionEvaluation.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -449,7 +449,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/BooleanExpressionEvaluation.xcodeproj/xcshareddata/xcschemes/BooleanExpressionEvaluation-Package.xcscheme
+++ b/BooleanExpressionEvaluation.xcodeproj/xcshareddata/xcschemes/BooleanExpressionEvaluation-Package.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. `BooleanExpressionEvaluation` adheres to [Semantic Versioning](http://semver.org).
 
 ---
+## [1.2.3](https://github.com/ABridoux/BooleanExpressionEvaluation/tree/1.2.3) (30/03/2020)
+
+### Fixed
+- The string regex pattern allowed to take anything between double quotes, even a double quote.
 
 ## [1.2.2](https://github.com/ABridoux/BooleanExpressionEvaluation/tree/1.2.2) (18/01/2019)
 

--- a/Sources/BooleanExpressionEvaluation/Expression/ExpressionElement.swift
+++ b/Sources/BooleanExpressionEvaluation/Expression/ExpressionElement.swift
@@ -78,7 +78,7 @@ public enum ExpressionElement: Equatable, CustomStringConvertible, Codable {
 
         static let booleanRegexPattern = "true|false"
         static let numberRegexPattern = #"[0-9\.]+"#
-        static let stringRegexPattern =  #"".*""#
+        static let stringRegexPattern =  #""[^"]*""#
         static let variableRegexPattern = "[a-zA-Z]{1}[a-zA-Z0-9_-]+"
 
         static func getRegexPattern(variablesRegexPattern: String? = nil) -> String {

--- a/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTestsIntegration.swift
+++ b/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTestsIntegration.swift
@@ -81,7 +81,7 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         }
     }
 
-    func testEvaluateString_WtihDebt() {
+    func testEvaluateString_WithDebt() {
         variables["variable"] = "1"
         variables["isCheck"] = "false"
         variables["Ducks"] = "Riri, Fifi,  Loulou"
@@ -96,6 +96,21 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         do {
             let result = try sut.evaluateExpression()
             XCTAssertTrue(result)
+        } catch {
+            XCTFail("Unable to evaluate the expression: \(error.localizedDescription)")
+        }
+    }
+
+    func testDoubleString() {
+        variables["variable"] = "Installed"
+        variables["var2"] = "Installed"
+
+        let expressionString = #"variable != "Installed" && var2 == "Installed""#
+
+        do {
+            var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+            let result = try sut!.evaluateExpression()
+            XCTAssertFalse(result)
         } catch {
             XCTFail("Unable to evaluate the expression: \(error.localizedDescription)")
         }


### PR DESCRIPTION
### Fixed
- The string regex pattern allowed to take anything between double quotes, even a double quote.