### PR TITLE
[#43/#41] Operator keyword

### DIFF
--- a/Sources/BooleanExpressionEvaluation/Expression/BooleanExpressionTokenizator.swift
+++ b/Sources/BooleanExpressionEvaluation/Expression/BooleanExpressionTokenizator.swift
@@ -205,19 +205,19 @@ struct BooleanExpressionTokenizator {
         switch remainingOperand {
 
         case .string(let string):
-            result = isLeftOperandAVariable ? comparisonOperator.evaluate(variableValue, string) : comparisonOperator.evaluate(string, variableValue)
+            result = try isLeftOperandAVariable ? comparisonOperator.evaluate(variableValue, string) : comparisonOperator.evaluate(string, variableValue)
 
         case .number(let double):
             guard let doubleVariableValue = Double(variableValue) else {
                 throw ExpressionError.mismatchingType
             }
-            result = isLeftOperandAVariable ? comparisonOperator.evaluate(doubleVariableValue, double) : comparisonOperator.evaluate(double, doubleVariableValue)
+            result = try isLeftOperandAVariable ? comparisonOperator.evaluate(doubleVariableValue, double) : comparisonOperator.evaluate(double, doubleVariableValue)
 
         case .boolean(let boolean):
             guard let booleanVariableValue = Bool(variableValue) else {
                 throw ExpressionError.mismatchingType
             }
-            result = isLeftOperandAVariable ? comparisonOperator.evaluate(booleanVariableValue, boolean) : comparisonOperator.evaluate(boolean, booleanVariableValue)
+            result = try isLeftOperandAVariable ? comparisonOperator.evaluate(booleanVariableValue, boolean) : comparisonOperator.evaluate(boolean, booleanVariableValue)
 
         case .variable(let otherVariableName):
             guard let otherVariableValue = variables[otherVariableName] else { return false }
@@ -236,12 +236,12 @@ struct BooleanExpressionTokenizator {
         var result: Bool?
 
         if let leftDouble = Double(leftVariableValue), let rightDouble = Double(rightVariableValue) {
-            result = comparisonOperator.evaluate(leftDouble, rightDouble)
+            result = try comparisonOperator.evaluate(leftDouble, rightDouble)
         } else if let leftBoolean = Bool(leftVariableValue), let rightBoolean = Bool(rightVariableValue) {
-            result = comparisonOperator.evaluate(leftBoolean, rightBoolean)
+            result = try comparisonOperator.evaluate(leftBoolean, rightBoolean)
         } else {
             // string comparison
-            result = comparisonOperator.evaluate(leftVariableValue, rightVariableValue)
+            result = try comparisonOperator.evaluate(leftVariableValue, rightVariableValue)
         }
 
         if let unwrappedResult = result {

--- a/Sources/BooleanExpressionEvaluation/Expression/Expression.swift
+++ b/Sources/BooleanExpressionEvaluation/Expression/Expression.swift
@@ -13,7 +13,12 @@ public struct Expression: Collection, CustomStringConvertible {
 
     // MARK: - Constants
 
-    static let operatorsPattern = "[\(Operator.regexPattern)\(ExpressionElement.LogicInfixOperator.regexPattern)\(ExpressionElement.LogicPrefixOperator.regexPattern)]+"
+    static var operatorsPattern: String {
+        "[\(Operator.regexPattern)" +
+        ExpressionElement.LogicInfixOperator.regexPattern +
+        "\(ExpressionElement.LogicPrefixOperator.regexPattern)]+" +
+        "|(\(Operator.regexKeywordPattern))+"
+    }
     static let bracketsPattern = #"[\(\)]+"#
 
     // MARK: - Properties

--- a/Sources/BooleanExpressionEvaluation/Expression/ExpressionError.swift
+++ b/Sources/BooleanExpressionEvaluation/Expression/ExpressionError.swift
@@ -18,6 +18,7 @@ public enum ExpressionError: LocalizedError, Equatable {
     case unbalancedBrackets
     case mismatchingType
     case wrongOperatorAndOperandsAssociation
+    case invalidOperand(description: String)
 
     public var errorDescription: String? {
         switch self {
@@ -31,6 +32,7 @@ public enum ExpressionError: LocalizedError, Equatable {
         case .unbalancedBrackets: return "The expression contains unbaled brackets"
         case .mismatchingType: return "The types of the two operands mistmatch"
         case .wrongOperatorAndOperandsAssociation: return "The operator cannot be applied to the operands because they do not have the rigth type"
+        case .invalidOperand(let description): return description
         }
     }
 }

--- a/Sources/BooleanExpressionEvaluation/Expression/Operator/OperatorProtocol.swift
+++ b/Sources/BooleanExpressionEvaluation/Expression/Operator/OperatorProtocol.swift
@@ -7,15 +7,32 @@ import Foundation
 public protocol OperatorProtocol: CustomStringConvertible, Hashable {
 
     static var models: Set<Self> { get }
+    var isKeyword: Bool { get }
 }
 
 extension OperatorProtocol {
 
+    public var isKeyword: Bool { false }
+
     /// The pattern to identify an operator with a regular expression
     static var regexPattern: String {
         var uniqueCharactersPattern = Set<String>()
-        models.forEach { $0.description.forEach {  uniqueCharactersPattern.insert(String($0).quoted) }}
+        for model in models where !model.isKeyword {
+            model.description.forEach {  uniqueCharactersPattern.insert(String($0).quoted) }
+        }
         return uniqueCharactersPattern.reduce("") { $0 + $1 }
+    }
+
+    /// Regex for the keywords (custom operators)
+    static var regexKeywordPattern: String {
+        let keywords = models.reduce([String]()) { (result, model) in
+            if model.isKeyword {
+                return result + [model.description]
+            }
+            return result
+        }
+
+        return keywords.joined(separator: "|")
     }
 
     /// - Parameter element: Element to compare to the description

--- a/Sources/BooleanExpressionEvaluation/Extensions/NSRegularExpression+Extensions.swift
+++ b/Sources/BooleanExpressionEvaluation/Extensions/NSRegularExpression+Extensions.swift
@@ -15,6 +15,26 @@ extension NSRegularExpression {
         return string[firstMatch.range] == string
     }
 
+    /// Validate a string if the first match found by the regex is the overall string
+    func validate(_ string: String) -> Bool {
+        guard
+            let firstMatch = firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.count)),
+            firstMatch.range.length >= 0
+        else {
+            return false
+        }
+
+        if firstMatch.range.length == 0 {
+            if string.isEmpty {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        return string[firstMatch.range] == string
+    }
+
     /// Characters that has to be quoted to be used in a regular expression
     static var charactersToQuote: [String] { ["*", "?", "+", "[", "(", ")", "{", "}", "^", "$", "|", "\\", ".", "/", "="] }
 

--- a/Tests/BooleanExpressionEvaluationTests/Expression/BooleanExpressionTokenizorTests.swift
+++ b/Tests/BooleanExpressionEvaluationTests/Expression/BooleanExpressionTokenizorTests.swift
@@ -287,7 +287,7 @@ class BooleanExpressionTokenizorTests: XCTestCase {
     func testEvaluateComparison_ContainsLeftOperandVariable() {
         sut.variables["ducks"] = "Riri, Fifi, Loulou"
 
-        let result = try? sut.evaluateCleanComparison(.variable("ducks"), .contains, .string("Riri"))
+        let result = try? sut.evaluateCleanComparison(.string("Riri"), .isIn, .variable("ducks"))
 
         XCTAssertEqual(result, true)
     }
@@ -295,7 +295,7 @@ class BooleanExpressionTokenizorTests: XCTestCase {
     func testEvaluateComparison_ContainsRightOperandVariable() {
         sut.variables["duck"] = "Riri"
 
-        let result = try? sut.evaluateCleanComparison(.string("Riri, Fifi, Loulou"), .contains, .variable("duck"))
+        let result = try? sut.evaluateCleanComparison(.variable("duck"), .isIn, .string("Riri, Fifi, Loulou"))
 
         XCTAssertEqual(result, true)
     }

--- a/Tests/BooleanExpressionEvaluationTests/Expression/BooleanExpressionTokenizorTestsIntegration.swift
+++ b/Tests/BooleanExpressionEvaluationTests/Expression/BooleanExpressionTokenizorTestsIntegration.swift
@@ -60,7 +60,7 @@ class BooleanExpressionTokenizorTestsIntegration: XCTestCase {
                                             .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                         .bracket(.closing),
                                         .logicInfixOperator(.or),
-                                            .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.string("Fifi"))]
+                                        .operand(.string("Fifi")), .comparisonOperator(.isIn), .operand(.variable("Ducks"))]
         let expectedTokenizdExpression: Expression = [.bracket(.opening),
                                                             .operand(.boolean(false)),
                                                       .logicInfixOperator(.and),

--- a/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTests.swift
+++ b/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTests.swift
@@ -100,7 +100,7 @@ class ExpressionEvaluatorTests: XCTestCase {
                                             .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                         .bracket(.closing),
                                         .logicInfixOperator(.or),
-                                            .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.string("Fifi"))]
+                                        .operand(.string("Fifi")), .comparisonOperator(.isIn), .operand(.variable("Ducks"))]
 
         var sut = ExpressionEvaluator(expression: expression, variables: variables)
 
@@ -117,7 +117,7 @@ class ExpressionEvaluatorTests: XCTestCase {
                                             .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                         .bracket(.closing),
                                         .logicInfixOperator(.or),
-                                            .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.string("Fifi"))]
+                                            .operand(.variable("Ducks")), .comparisonOperator(.isIn), .operand(.string("Fifi"))]
 
         var sut = ExpressionEvaluator(expression: expression, variables: variables)
         XCTAssertThrowsError(try sut.evaluateExpression(), "") { error in
@@ -137,7 +137,7 @@ class ExpressionEvaluatorTests: XCTestCase {
                                       .logicInfixOperator(.and),
                                             .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                         .logicInfixOperator(.or),
-                                            .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.variable("Fifi"))]
+                                            .operand(.variable("Ducks")), .comparisonOperator(.isIn), .operand(.variable("Fifi"))]
 
         var sut = ExpressionEvaluator(expression: expression, variables: variables)
 
@@ -160,7 +160,7 @@ class ExpressionEvaluatorTests: XCTestCase {
                                         .bracket(.opening),
                                             .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                         .logicInfixOperator(.or),
-                                            .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.string("Fifi")),
+                                            .operand(.variable("Ducks")), .comparisonOperator(.isIn), .operand(.string("Fifi")),
                                         .bracket(.closing),
                                         .bracket(.closing)]
 
@@ -184,7 +184,7 @@ class ExpressionEvaluatorTests: XCTestCase {
                                         .logicInfixOperator(.and),
                                             .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                         .logicInfixOperator(.or),
-                                            .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.string("Fifi")),
+                                        .operand(.string("Fifi")), .comparisonOperator(.isIn), .operand(.variable("Ducks")),
                                         .bracket(.closing), .bracket(.closing), .bracket(.closing)]
 
         var sut = ExpressionEvaluator(expression: expression, variables: variables)
@@ -206,7 +206,7 @@ class ExpressionEvaluatorTests: XCTestCase {
                                       .logicInfixOperator(.or),
                                       .operand(.variable("isCheck")), .comparisonOperator(.equal), .operand(.boolean(true)),
                                       .logicInfixOperator(.and),
-                                      .operand(.variable("Ducks")), .comparisonOperator(.contains), .operand(.string("Fifi")) ]
+                                      .operand(.variable("Ducks")), .comparisonOperator(.isIn), .operand(.string("Fifi")) ]
 
         var sut = ExpressionEvaluator(expression: expression, variables: variables)
 

--- a/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTestsIntegration.swift
+++ b/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTestsIntegration.swift
@@ -24,7 +24,7 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         variables["variable"] = "1"
         variables["isCheck"] = "false"
         variables["Ducks"] = "Riri, Fifi, Loulou"
-        let expressionString = #"(variable == 1 && isCheck == false) || Ducks <: "Fifi""#
+        let expressionString = #"(variable == 1 && isCheck == false) || "Fifi" isIn Ducks"#
         var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
 
         let result = try XCTUnwrap(sut?.evaluateExpression())
@@ -37,7 +37,7 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         variables["isCheck"] = "false"
         variables["Ducks"] = "Riri, Fifi,  Loulou"
         variables["duck"] = "Riri"
-        let expressionString = #"variable == 1 || isCheck && Ducks <: duck"#
+        let expressionString = #"variable == 1 || isCheck && duck isIn Ducks"#
         var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
 
         let result = try XCTUnwrap(sut?.evaluateExpression())
@@ -74,7 +74,7 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         variables["isCheck"] = "false"
         variables["Ducks"] = "Riri, Fifi,  Loulou"
         variables["duck"] = "Riri"
-        let expressionString = #"variable != 1 || isCheck != true && Ducks <: duck"#
+        let expressionString = #"variable != 1 || isCheck != true && duck isIn Ducks"#
         var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
 
         let result = try XCTUnwrap(sut?.evaluateExpression())
@@ -133,5 +133,75 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         let result = try XCTUnwrap(sut?.evaluateExpression())
 
         XCTAssertTrue(result)
+    }
+
+    // MARK: - Test default operators
+
+    func testHasPrefix() throws {
+        variables["variable"] = "Loulou"
+        let expressionString = "variable hasPrefix 'Lou'"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testHasSuffix() throws {
+        variables["variable"] = "Loulou"
+        let expressionString = "variable hasSuffix 'lou'"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testIsIn() throws {
+        variables["Ducks"] = "Riri, Fifi, Loulou"
+        let expressionString = "'Fifi' isIn Ducks"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testContains() throws {
+        variables["variable"] = "Loulou"
+        let expressionString = "variable contains 'oulo'"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testMatches() throws {
+        variables["variable"] = "123"
+        let expressionString = "variable matches '[0-9]{3}'"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testMatches2() throws {
+        variables["variable"] = "Loulou"
+        let expressionString = "variable matches '.*ulou.*'"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testMatchesInvalidRegex() throws {
+        variables["variable"] = "123"
+        let expressionString = "variable matches '[0-9{3}'"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        XCTAssertErrorsEqual(try sut?.evaluateExpression(), .invalidOperand(description: "The regular expression '[0-9{3}' is invalid"))
     }
 }

--- a/Tests/BooleanExpressionEvaluationTests/StringExtensionsTests.swift
+++ b/Tests/BooleanExpressionEvaluationTests/StringExtensionsTests.swift
@@ -1,0 +1,15 @@
+//
+// Scout
+// Copyright (c) Alexis Bridoux 2020
+// MIT license, see LICENSE file for details
+
+import Foundation
+import XCTest
+@testable import BooleanExpressionEvaluation
+
+final class StringExtensionsTests: XCTestCase {
+
+    func testQuotedOperatorCharactersIdentity() {
+        XCTAssertEqual("hasPrefix".quoted, "hasPrefix")
+    }
+}


### PR DESCRIPTION
- The custom operators are now specified with names rather than custom symbols. This is made be possible my marking them as "keyword" at initialisation
- Added the "matches" operator to match a whole string against a regular expression