### PR TITLE
[#42] Support escaped command in isIn operator list

### DIFF
--- a/Sources/BooleanExpressionEvaluation/Expression/Operator/Operator.swift
+++ b/Sources/BooleanExpressionEvaluation/Expression/Operator/Operator.swift
@@ -106,8 +106,24 @@ extension Operator {
 
     static var isIn: Operator { Operator("isIn", isKeyword: true) { (lhs, rhs) in
         guard let lhs = lhs as? String, let rhs = rhs as? String else { return nil }
-        let splittedRhs = rhs.split(separator: ",").map { String($0.trimmingCharacters(in: .whitespaces)) }
-        return splittedRhs.contains(lhs)
+        var escapedComma = false
+
+        return rhs
+            .split(separator: ",")
+            .reduce([String]()) { (result, substring) in
+                var result = result
+
+                if escapedComma, let last = result.last {
+                    result[result.count - 1] = last + "," + String(substring)
+                } else {
+                    result.append(String(substring))
+                }
+                
+                escapedComma = substring.hasSuffix("\\")
+                return result
+            }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } // trim after a possible matches union
+            .contains(lhs)
     }}
 
     static var matches: Operator { Operator("matches", isKeyword: true) { (lhs, rhs) in

--- a/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTestsIntegration.swift
+++ b/Tests/BooleanExpressionEvaluationTests/Expression/ExpressionEvaluatorTestsIntegration.swift
@@ -167,6 +167,26 @@ class ExpressionEvaluatorTestsIntegration: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func testIsInEscapedComma() throws {
+        variables["Ducks"] = #"Riri\, Fifi, Loulou"#
+        let expressionString = #"'Riri\, Fifi' isIn Ducks"#
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertTrue(result)
+    }
+
+    func testIsInEscapedComma2() throws {
+        variables["Ducks"] = #"Riri, Fifi\, Loulou"#
+        let expressionString = "'Fifi' isIn Ducks"
+        var sut = try ExpressionEvaluator(string: expressionString, variables: variables)
+
+        let result = try XCTUnwrap(sut?.evaluateExpression())
+
+        XCTAssertFalse(result)
+    }
+
     func testContains() throws {
         variables["variable"] = "Loulou"
         let expressionString = "variable contains 'oulo'"


### PR DESCRIPTION
Commas can be escaped with ”\”